### PR TITLE
Update gitignore so that it works on multiple dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,63 @@
-/target
+# Compiled source #
+###################
+#*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+##Eclipse related files
+##########
+.classpath
+.project
+*.settings
+
+##CQ5 JCR related files
+.vlt
+
+## ignore maven generated files
+bundle/target/
+target/
+
+## ignore vim temp files
+*.swp
+*.swn
+*.swo
+
+## intellij idea
+*.iml
+.idea/
+/.metadata/*.lock
+/.metadata
+


### PR DESCRIPTION
This update to the .gitignore file adds ignore rules for various OS files and project files for Eclipse and IntelliJ, for people who fork in the future who use other OS's and IDEs. 